### PR TITLE
AEM-90, AEM-78 - Update acs commons and service pack

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <aem.version>6.4.2</aem.version>
         <sling.version>1.2.2</sling.version>
         <geronimo.version>1.0</geronimo.version>
-        <acs-commons.version>3.17.0</acs-commons.version>
+        <acs-commons.version>3.19.0</acs-commons.version>
         <servlet.api.version>3.1.0</servlet.api.version>
         <jsp.api.version>2.1</jsp.api.version>
         <jcr.version>2.0</jcr.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </distributionManagement>
 
     <properties>
-        <aem.version>6.4.1</aem.version>
+        <aem.version>6.4.2</aem.version>
         <sling.version>1.2.2</sling.version>
         <geronimo.version>1.0</geronimo.version>
         <acs-commons.version>3.17.0</acs-commons.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.cru</groupId>
     <artifactId>aem-bom</artifactId>
     <packaging>pom</packaging>
-    <version>1.1</version>
+    <version>1.2</version>
     <description>AEM Bill of Materials</description>
 
     <scm>


### PR DESCRIPTION
This PR updates the code to use the same versions as the new ones in AEM.
[AEM-90](https://jira.cru.org/browse/AEM-90)
[AEM-78](https://jira.cru.org/browse/AEM-78)