### PR TITLE
AEM-187 - add cru-aem-commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.cru</groupId>
     <artifactId>aem-bom</artifactId>
     <packaging>pom</packaging>
-    <version>1.3</version>
+    <version>1.4</version>
     <description>AEM Bill of Materials</description>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <junit.addons.version>1.4</junit.addons.version>
         <mockito.version>1.9.5</mockito.version>
         <cru-aem-commons.version>1.3.3</cru-aem-commons.version>
+        <logback.version>1.2.3</logback.version>
     </properties>
 
     <dependencyManagement>
@@ -100,6 +101,14 @@
                 <groupId>org.cru</groupId>
                 <artifactId>cru-aem-commons.core</artifactId>
                 <version>${cru-aem-commons.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- Logging -->
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <jackson.version>2.8.4</jackson.version>
         <junit.addons.version>1.4</junit.addons.version>
         <mockito.version>1.9.5</mockito.version>
+        <cru-aem-commons.version>1.3.3</cru-aem-commons.version>
     </properties>
 
     <dependencyManagement>
@@ -91,6 +92,14 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
                 <version>${jackson.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- Cru Custom -->
+            <dependency>
+                <groupId>org.cru</groupId>
+                <artifactId>cru-aem-commons.core</artifactId>
+                <version>${cru-aem-commons.version}</version>
                 <scope>provided</scope>
             </dependency>
 


### PR DESCRIPTION
This PR includes `cru-aem-commons` in the BoM so that we don't have to update its version in every project every time we update the commons library (though I guess we'll still have to update the BoM version).