### PR TITLE
Release 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </distributionManagement>
 
     <properties>
-        <io.wcm.aem.version>6.4.2.0000</io.wcm.aem.version>
+        <io.wcm.aem.version>6.4.5.0000</io.wcm.aem.version>
         <io.wcm.aem.mock.version>2.5.0</io.wcm.aem.mock.version>
         <acs-commons.version>3.19.0</acs-commons.version>
         <taglib.version>5.7.4</taglib.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
         <acs-commons.version>3.19.0</acs-commons.version>
         <taglib.version>5.7.4</taglib.version>
         <guava.version>22.0</guava.version>
-        <jackson.version>2.8.4</jackson.version>
         <junit.addons.version>1.4</junit.addons.version>
         <mockito.version>1.9.5</mockito.version>
         <cru-aem-commons.version>1.3.3</cru-aem-commons.version>
@@ -73,26 +72,6 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <!-- Jackson -->
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>${jackson.version}</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.cru</groupId>
     <artifactId>aem-bom</artifactId>
     <packaging>pom</packaging>
-    <version>1.4</version>
+    <version>1.5</version>
     <description>AEM Bill of Materials</description>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <io.wcm.aem.version>6.4.5.0000</io.wcm.aem.version>
         <io.wcm.aem.mock.version>2.5.0</io.wcm.aem.mock.version>
         <acs-commons.version>3.19.0</acs-commons.version>
-        <taglib.version>5.12.10</taglib.version>
+        <taglib.version>5.8.2</taglib.version> <!-- The version in AEM is 5.12.10, but it doesn't exist in Maven -->
         <guava.version>22.0</guava.version>
         <junit.addons.version>1.4</junit.addons.version>
         <mockito.version>1.9.5</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <io.wcm.aem.version>6.4.5.0000</io.wcm.aem.version>
         <io.wcm.aem.mock.version>2.5.0</io.wcm.aem.mock.version>
         <acs-commons.version>3.19.0</acs-commons.version>
-        <taglib.version>5.7.4</taglib.version>
+        <taglib.version>5.12.10</taglib.version>
         <guava.version>22.0</guava.version>
         <junit.addons.version>1.4</junit.addons.version>
         <mockito.version>1.9.5</mockito.version>


### PR DESCRIPTION
This PR does a few things:

- Updates the AEM version of wcm.io to match our current version in production
- Removes explicit dependencies that are managed by wcm.io
- Updates the taglib dependency (which I'm not entirely sure we're actually using, that needs more research. It's declared in the ui.apps in many projects, but not sure if that would still be added in a new archetype build)