### PR TITLE
Javax annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.cru</groupId>
     <artifactId>aem-bom</artifactId>
     <packaging>pom</packaging>
-    <version>1.5.6</version>
+    <version>1.5.7</version>
     <description>AEM Bill of Materials</description>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <mockito.version>1.9.5</mockito.version>
         <cru-aem-commons.version>1.3.13</cru-aem-commons.version>
         <logback.version>1.2.3</logback.version>
+        <javax.annotation.version>1.3.2</javax.annotation.version>
     </properties>
 
     <dependencyManagement>
@@ -72,6 +73,13 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>${javax.annotation.version}</version>
                 <scope>provided</scope>
             </dependency>
 


### PR DESCRIPTION
Update the javax.annotation dependency such that we control it. The old version is gone in AEM 6.5.